### PR TITLE
return error interface instead of concrete types

### DIFF
--- a/error.go
+++ b/error.go
@@ -88,7 +88,7 @@ type Error struct {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The stacktrace will point to the line of code that
 // called New.
-func NewError(e interface{}) *Error {
+func NewError(e interface{}) error {
 	var err error
 
 	switch e := e.(type) {
@@ -111,7 +111,7 @@ func NewError(e interface{}) *Error {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The skip parameter indicates how far up the stack
 // to start the stacktrace. 0 is from the current call, 1 from its caller, etc.
-func Wrap(e interface{}, skip int) *Error {
+func Wrap(e interface{}, skip int) error {
 	var err error
 
 	switch e := e.(type) {
@@ -138,9 +138,9 @@ func Wrap(e interface{}, skip int) *Error {
 // error message when calling Error(). The skip parameter indicates how far
 // up the stack to start the stacktrace. 0 is from the current call,
 // 1 from its caller, etc.
-func WrapPrefix(e interface{}, prefix string, skip int) *Error {
+func WrapPrefix(e interface{}, prefix string, skip int) error {
 
-	err := Wrap(e, skip)
+	err := Wrap(e, skip).(*Error)
 
 	if err.prefix != "" {
 		err.prefix = fmt.Sprintf("%s: %s", prefix, err.prefix)
@@ -193,7 +193,7 @@ func Is(e error, original error) bool {
 // Errorf creates a new error with the given message. You can use it
 // as a drop-in replacement for fmt.Errorf() to provide descriptive
 // errors in return values.
-func Errorf(format string, a ...interface{}) *Error {
+func Errorf(format string, a ...interface{}) error {
 	return Wrap(fmt.Errorf(format, a...), 1)
 }
 
@@ -252,8 +252,8 @@ func (err *Error) TypeName() string {
 // provide helpful error messages, while retaining the ability to be compared.
 func Newf(s string) Errf {
 	id := newid()
-	return func(args ...interface{}) *Error {
-		e := Errorf(s, args...)
+	return func(args ...interface{}) error {
+		e := Errorf(s, args...).(*Error)
 		e.id = id
 		return e
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -16,7 +16,7 @@ func TestStackFormatMatches(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		bs := [][]byte{Errorf("hi").Stack(), debug.Stack()}
+		bs := [][]byte{Errorf("hi").(*Error).Stack(), debug.Stack()}
 
 		// Ignore the first line (as it contains the PC of the .Stack() call)
 		bs[0] = bytes.SplitN(bs[0], []byte("\n"), 2)[1]
@@ -40,7 +40,7 @@ func TestSkipWorks(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		bs := [][]byte{Wrap("hi", 2).Stack(), debug.Stack()}
+		bs := [][]byte{Wrap("hi", 2).(*Error).Stack(), debug.Stack()}
 
 		// should skip four lines of debug.Stack()
 		bs[1] = bytes.SplitN(bs[1], []byte("\n"), 5)[4]
@@ -57,19 +57,19 @@ func TestSkipWorks(t *testing.T) {
 
 func TestNewError(t *testing.T) {
 
-	err := NewError("foo")
+	err := NewError("foo").(*Error)
 
 	if err.Error() != "foo" {
 		t.Errorf("Wrong message")
 	}
 
-	err = NewError(fmt.Errorf("foo"))
+	err = NewError(fmt.Errorf("foo")).(*Error)
 
 	if err.Error() != "foo" {
 		t.Errorf("Wrong message")
 	}
 
-	bs := [][]byte{NewError("foo").Stack(), debug.Stack()}
+	bs := [][]byte{NewError("foo").(*Error).Stack(), debug.Stack()}
 
 	// Ignore the first line (as it contains the PC of the .Stack() call)
 	bs[0] = bytes.SplitN(bs[0], []byte("\n"), 2)[1]
@@ -148,7 +148,7 @@ func TestWrapPrefixError(t *testing.T) {
 		t.Errorf("Constructor with an error failed")
 	}
 
-	prefixed := WrapPrefix(e, "prefix", 0)
+	prefixed := WrapPrefix(e, "prefix", 0).(*Error)
 	original := e.(*Error)
 
 	if prefixed.Err != original.Err || &prefixed.stack != &original.stack || &prefixed.frames != &original.frames || prefixed.Error() != "prefix: prefix: hi" {

--- a/errors.go
+++ b/errors.go
@@ -12,26 +12,25 @@ type Errors struct {
 }
 
 // Errf is a closure around Errorf to provide comparable but descriptive errors
-type Errf func(...interface{}) *Error
+type Errf func(...interface{}) error
 
 // Add returns a list of errors that contains both parameters, no matter their error type.
-func Add(e interface{}, ee interface{}) *Errors {
+func Add(e interface{}, ee interface{}) error {
 	if errs, ok := e.(*Errors); ok {
 		return errs.Add(ee)
 	} else if err, ok := e.(*Error); ok {
 		errs := &Errors{errs: make([]*Error, 0)}
-		errs = errs.Add(err)
+		errs = errs.Add(err).(*Errors)
 		return errs.Add(ee)
 	} else {
-		errs := New(ee)
-		return errs.Add(ee)
+		return New(ee)
 	}
 }
 
 // Add returns a list of errors with the parameter added to the receiver,
 // it will behave correctly with a simple error, as well as with an errors.Error and an errors.Errors as parameters.
 // It will also log the error using glog if a verbosity of 3 or more is specified.
-func (e *Errors) Add(ee interface{}) *Errors {
+func (e *Errors) Add(ee interface{}) error {
 	if ee != nil {
 		var err error
 
@@ -61,7 +60,7 @@ func (e *Errors) Add(ee interface{}) *Errors {
 }
 
 // Addf is a wrapper around Add to simply add a descriptive error to the list.
-func (e *Errors) Addf(fmts string, args ...interface{}) *Errors {
+func (e *Errors) Addf(fmts string, args ...interface{}) error {
 	return e.Add(fmt.Errorf(fmts, args...))
 }
 
@@ -114,7 +113,7 @@ func (e *Errors) Is(ee error) bool {
 }
 
 // New returns a list of errors with the parameter added to the list.
-func New(err interface{}) *Errors {
+func New(err interface{}) error {
 	if err != nil {
 		e := &Errors{errs: make([]*Error, 0)}
 		return e.Add(err)

--- a/errors_test.go
+++ b/errors_test.go
@@ -6,44 +6,40 @@ import (
 
 func TestErrorsAdd(t *testing.T) {
 	bogus := NewError("bogus")
-	errs := New(bogus)
+	errs := New(bogus).(*Errors)
 	if !Is(errs.errs[0], bogus) {
 		t.Errorf("errs[%d] Is not %#v, it is %#v", 0, bogus, errs.errs[0])
 	}
 	bogusf := Newf("%d")
-	errs = errs.Add(bogusf(1))
+	errs = errs.Add(bogusf(1)).(*Errors)
 	if !Is(errs.errs[1], bogusf()) {
 		t.Errorf("errs[%d] Is not %#v, it is %#v", 1, bogusf(), errs.errs[1])
 	}
-	errs = errs.Add(bogusf(2))
+	errs = errs.Add(bogusf(2)).(*Errors)
 	if !Is(errs.errs[1], errs.errs[2]) {
 		t.Errorf("errs[%d] Is not %#v, it is %#v", 1, errs.errs[2], errs.errs[1])
 	}
-	errs = New(nil)
-	if errs != nil {
-		t.Error("errs should be nil, but it isn't")
-	}
-	if errs.Add(nil) != nil {
-		t.Error("errs.Add(nil) should be nil but it isn't")
+	if New(nil) != nil {
+		t.Error("New(nil) should be nil, but it isn't")
 	}
 }
 
 func TestAdd(t *testing.T) {
 	bogusf := Newf("%d is bogus")
-	errs := New(bogusf(1))
-	errs = Add(errs, bogusf(2))
+	errs := New(bogusf(1)).(*Errors)
+	errs = Add(errs, bogusf(2)).(*Errors)
 	for i, e := range errs.errs {
 		if !Is(e, bogusf()) {
 			t.Errorf("errs[%d] Is not bogusf (%#v)", i, bogusf())
 		}
 	}
-	errs = Add(bogusf(1), bogusf(2))
+	errs = Add(bogusf(1), bogusf(2)).(*Errors)
 	for i, e := range errs.errs {
 		if !Is(e, bogusf()) {
 			t.Errorf("errs[%d] Is not bogusf (%#v)", i, bogusf())
 		}
 	}
-	errs = Add(errs, errs)
+	errs = Add(errs, errs).(*Errors)
 	if !Is(errs.errs[0], errs.errs[2]) {
 		t.Errorf("errs[0] Is not errs[2]")
 	}
@@ -52,6 +48,9 @@ func TestAdd(t *testing.T) {
 	}
 	if !Is(errs, bogusf()) {
 		t.Errorf("errs is not bogusf (%#v)", errs, bogusf)
+	}
+	if Add(nil, nil) != nil {
+		t.Errorf("Add(nil, nil) should be nil, but it isn't")
 	}
 }
 


### PR DESCRIPTION
avoids tricky stuff like: http://dpaste.com/010R2FQ and generally allows more transparent use of the package. A potential downside is that caller systematically needs type cast to use package features
