### PR TITLE
add ErrorStacker interface

### DIFF
--- a/error.go
+++ b/error.go
@@ -190,6 +190,11 @@ func Is(e error, original error) bool {
 	return false
 }
 
+// Is satisfies the ErrorStacker interface, it is a wrapper to Is(error, error)
+func (e *Error) Is(original error) bool {
+	return Is(e, original)
+}
+
 // Errorf creates a new error with the given message. You can use it
 // as a drop-in replacement for fmt.Errorf() to provide descriptive
 // errors in return values.
@@ -221,7 +226,7 @@ func (err *Error) Stack() []byte {
 }
 
 // ErrorStack returns a string that contains both the
-// error message and the callstack.
+// error message and the callstack. Satisfies the ErrorStacker interface.
 func (err *Error) ErrorStack() string {
 	return err.TypeName() + " " + err.Error() + "\n" + string(err.Stack())
 }

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,15 @@ import (
 	"strings"
 )
 
+// ErrorStacker is an interface satisfying the error interface that is also
+// aware of the stackcall of the error, printed with ErrorStack(), and able
+// to compare itself to another error with Is(error)
+type ErrorStacker interface {
+	error
+	ErrorStack() string
+	Is(error) bool
+}
+
 // Errors is a list of errors with stack traces. It implements the error interface
 type Errors struct {
 	errs []*Error
@@ -65,6 +74,7 @@ func (e *Errors) Addf(fmts string, args ...interface{}) error {
 }
 
 // ErrorStack returns all the stack traces and error messages of the included errors.
+// Satisfies the ErrorStacker interface.
 func (e *Errors) ErrorStack() string {
 	if e == nil {
 		return ""
@@ -90,6 +100,7 @@ func (e *Errors) Error() string {
 
 // Is checks whether the parameter error is contained in the list of errors.
 // If the parameter is an errors.Errors, it will check whether at least one of their errors match.
+// Satisfies the ErrorStacker interface.
 func (e *Errors) Is(ee error) bool {
 	if e == nil && ee == nil {
 		return true

--- a/errors_test.go
+++ b/errors_test.go
@@ -82,3 +82,44 @@ func TestErrf(t *testing.T) {
 		t.Error("bogusf1(1) is not bogusf1")
 	}
 }
+
+func TestErrorStacker(t *testing.T) {
+	var (
+		errorStacker ErrorStacker
+		err          *Error
+		errs         *Errors
+	)
+
+	err = Errorf("*Error").(*Error)
+	errorStacker = ErrorStacker(err)
+	if !errorStacker.Is(err) {
+		t.Error("!errorStacker.Is(err)")
+	}
+	stackString := errorStacker.ErrorStack()
+
+	errs = New(err).(*Errors)
+	errorStacker = ErrorStacker(errs)
+	if !errorStacker.Is(errs) {
+		t.Error("!errorStacker.Is(errs)")
+	}
+	if !errorStacker.Is(err) {
+		t.Error("!errorStacker.Is(err)")
+	}
+	if errorStacker.ErrorStack() != stackString {
+		t.Errorf(
+			"errorStacker.ErrorStack() != stackString\n  errorStacker.ErrorStack(): %s\n  stackString: %s",
+			errorStacker.ErrorStack(), stackString)
+	}
+
+	// from generic error interface to ErrorStack interface - cast required
+	var err1 error
+	var ok bool
+	err1 = err // type *Error, stored as error interface
+	if errorStacker, ok = err1.(ErrorStacker); !ok {
+		t.Error("err1 (interface error, underlying *Error type)")
+	}
+	err1 = errs // type *Errors, stored as error interface
+	if errorStacker, ok = err1.(ErrorStacker); !ok {
+		t.Error("err1 (interface error, underlying *Errors type)")
+	}
+}


### PR DESCRIPTION
usually a user of the package will look to use ErrorStack() function to see the state of the callstack. Right now 2 different types provide this func, *Error and *Errors, which means that both types have to be try-casted in order to print the ErrorStack.

go interface to the rescue!
