### PR TITLE
NewError returns nil if nil is passed as param

### DIFF
--- a/error.go
+++ b/error.go
@@ -89,6 +89,10 @@ type Error struct {
 // fmt.Errorf("%v"). The stacktrace will point to the line of code that
 // called New.
 func NewError(e interface{}) error {
+	if e == nil {
+		return nil
+	}
+
 	var err error
 
 	switch e := e.(type) {

--- a/error_test.go
+++ b/error_test.go
@@ -84,6 +84,10 @@ func TestNewError(t *testing.T) {
 	if err.ErrorStack() != err.TypeName()+" "+err.Error()+"\n"+string(err.Stack()) {
 		t.Errorf("ErrorStack is in the wrong format")
 	}
+
+	if NewError(nil) != nil {
+		t.Errorf("NewError(nil) != nil")
+	}
 }
 
 func TestIs(t *testing.T) {


### PR DESCRIPTION
for usage conveniance & consistancy with errors.New(nil)
