### PR TITLE
add wrappers for os.IsExist, os.IsNotExist, os.IsPermission

### DIFF
--- a/isfunc.go
+++ b/isfunc.go
@@ -1,0 +1,40 @@
+package errors
+
+import "os"
+
+// IsNotExist checks for os.IsNotExist on provided error,
+// whether it is an *Errors, *Error, or error
+func IsNotExist(err error) bool {
+	return IsFunc(os.IsNotExist, err)
+}
+
+// IsExist checks for os.IsExist on provided error,
+// whether it is an *Errors, *Error, or error
+func IsExist(err error) bool {
+	return IsFunc(os.IsExist, err)
+}
+
+// IsPermission checks for os.IsPermission on provided error,
+// whether it is an *Errors, *Error, or error
+func IsPermission(err error) bool {
+	return IsFunc(os.IsPermission, err)
+}
+
+// IsFunc try-casts err for *Error or *Errors,
+// and checks the underlying error(s) against provided fn.
+// If error is not of type *Error or *Errors, IsFunc simply calls fn(err)
+func IsFunc(fn func(error) bool, err error) bool {
+	switch err.(type) {
+	case *Error:
+		return fn(err.(*Error).Err)
+	case *Errors:
+		for _, errn := range err.(*Errors).errs {
+			if fn(errn.Err) {
+				return true
+			}
+		}
+		return false
+	default:
+		return fn(err)
+	}
+}

--- a/isfunc_test.go
+++ b/isfunc_test.go
@@ -1,0 +1,118 @@
+package errors
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestIsNotExist(t *testing.T) {
+	tmp, err := ioutil.TempDir(os.TempDir(), "errors_TestIsNotExist")
+	defer os.RemoveAll(tmp)
+	if err != nil {
+		t.Fatal("ioutil.TempDir")
+	}
+
+	_, err = os.Open(path.Join(tmp, "fantom"))
+	if !os.IsNotExist(err) {
+		t.Fatal("!os.IsNotExist(err)")
+	}
+
+	if !IsNotExist(err) {
+		t.Errorf("IsNotExist for standard error should be true")
+	}
+
+	err = NewError(err)
+	if !IsNotExist(err) {
+		t.Errorf("IsNotExist for *Error should be true")
+	}
+
+	err = New(err)
+	if !IsNotExist(err) {
+		t.Errorf("IsNotExist for *Errors should be true (1)")
+	}
+
+	errs := new(Errors)
+	errs.Add(Errorf("dumb"))
+	errs.Add(err)
+	errs.Add(Errorf("dumber"))
+	if !IsNotExist(errs) {
+		t.Errorf("IsNotExist for *Errors should be true (2)")
+	}
+}
+
+func TestIsExist(t *testing.T) {
+	tmp, err := ioutil.TempDir(os.TempDir(), "errors_TestIsExist")
+	defer os.RemoveAll(tmp)
+	if err != nil {
+		t.Fatal("ioutil.TempDir")
+	}
+	err = os.Mkdir(tmp, 0777)
+	if !os.IsExist(err) {
+		t.Fatal("!os.IsExist(err)")
+	}
+
+	if !IsExist(err) {
+		t.Errorf("IsExist for standard error should be true")
+	}
+
+	err = NewError(err)
+	if !IsExist(err) {
+		t.Errorf("IsExist for *Error should be true")
+	}
+
+	err = New(err)
+	if !IsExist(err) {
+		t.Errorf("IsExist for *Errors should be true (1)")
+	}
+
+	errs := new(Errors)
+	errs.Add(Errorf("dumb"))
+	errs.Add(err)
+	errs.Add(Errorf("dumber"))
+	if !IsExist(errs) {
+		t.Errorf("IsExist for *Errors should be true (2)")
+	}
+}
+
+func TestIsPermission(t *testing.T) {
+	tmp, err := ioutil.TempDir(os.TempDir(), "errors_TestIsPermission")
+	defer os.RemoveAll(tmp)
+	if err != nil {
+		t.Fatal("ioutil.TempDir")
+	}
+
+	autistDir := path.Join(tmp, "autism")
+	err = os.Mkdir(autistDir, 0)
+	if err != nil {
+		t.Fatal("os.Mkdir")
+	}
+
+	_, err = os.Create(path.Join(autistDir, "pwease"))
+	if !os.IsPermission(err) {
+		t.Fatal("!os.IsPermission(err)")
+	}
+
+	if !IsPermission(err) {
+		t.Errorf("!IsPermission(err)")
+	}
+
+	err = NewError(err)
+	if !IsPermission(err) {
+		t.Errorf("IsPermission for *Error should be true")
+	}
+
+	err = New(err)
+	if !IsPermission(err) {
+		t.Errorf("IsPermission for *Errors should be true (1)")
+	}
+
+	errs := new(Errors)
+	errs.Add(Errorf("dumb"))
+	errs.Add(err)
+	errs.Add(Errorf("dumber"))
+	if !IsPermission(errs) {
+		t.Errorf("IsPermission for *Errors should be true (2)")
+	}
+}


### PR DESCRIPTION
There's an issue with standard Is*(error) functions if we wrapped a standard error into an *Error or *Errors.

Basically they check for the type of the error, which should be os.PathError, but since it is already bundled it needs to check for underlying err.Err.

I've thought of several workarounds for this, but I think this is the simpler/cleaner approach if we want to keep a consistant use of this library
